### PR TITLE
Fixes time_stamp attr naming

### DIFF
--- a/lib/nist_randomness_beacon/record.rb
+++ b/lib/nist_randomness_beacon/record.rb
@@ -1,6 +1,6 @@
 module NISTRandomnessBeacon
   class Record
-    attr_reader :version, :frequency, :timestamp, :seed_value,
+    attr_reader :version, :frequency, :time_stamp, :seed_value,
                 :previous_output_value, :signature_value, :output_value,
                 :status_code
 


### PR DESCRIPTION
`timestamp` should be `time_stamp`

```xml
<record>
  <timeStamp>1434836640</timeStamp>
</record>
```